### PR TITLE
Update ban.lua

### DIFF
--- a/otxserver2/path_86x/data/talkactions/scripts/ban.lua
+++ b/otxserver2/path_86x/data/talkactions/scripts/ban.lua
@@ -1,16 +1,29 @@
-local TYPE_ACCESS = {
-	[1] = { "Player" },
-	[2] = { "Player" },
-	[3] = { "Account", "Player" },
-	[4] = { "Account", "Player" },
-	[5] = { "Account", "Player", "IP" }
-}
-
-function onSay(cid, words, param, channel)
-	unregisterCreatureEventType(cid, "channelrequest")
-	unregisterCreatureEventType(cid, "textedit")
-
-	doPlayerSendChannels(cid, TYPE_ACCESS[getPlayerAccess(cid)])
-	registerCreatureEvent(cid, "Ban_Type")
-	return true
+function onSay(cid, words, param)
+local parametres = string.explode(param, ",")
+if(parametres[1] ~= nil) then
+local accId = getAccountIdByName(parametres[1])
+if(accId > 0) then
+local comment = ""
+if(parametres[2] == nil) then
+doPlayerSendCancel(cid, "You must enter ban days.")
+return true
+elseif(isNumber(parametres[2]) == false) then
+doPlayerSendCancel(cid, "Ban days use only numbers.")
+return true
+end
+if(parametres[3] ~= nil) then
+comment = parametres[3]
+end
+doAddAccountBanishment(accId, getPlayerGUIDByName(parametres[1]), os.time() + (86400 * parametres[2]), 4, 2, comment, getPlayerGUID(cid), '')
+local player = getPlayerByNameWildcard(parametres[1])
+if(isPlayer(player) == TRUE) then
+doRemoveCreature(player)
+end
+else
+doPlayerSendCancel(cid, "Player with name " .. parametres[1] .. " doesn't exist.")
+end
+else
+doPlayerSendCancel(cid, "You must enter name.")
+end
+return true
 end


### PR DESCRIPTION
Este command ban presenta problemas como por ejemplo gesior al banear el char desaparece. Con este nuevo comando funciona todo correctamente. Funcionando de la siguiente manera:
/ban Player name, dias, comentario. Ejemplo:
/ban Kaiser, 90, Bot.
