### PR TITLE
Creating dedicated method to set creature master

### DIFF
--- a/path_10_9/data/lib/compat/compat.lua
+++ b/path_10_9/data/lib/compat/compat.lua
@@ -546,7 +546,7 @@ function doConvinceCreature(cid, target)
 		return false
 	end
 
-	targetCreature:setMaster(creature)
+	targetCreature:convince(creature)
 	return true
 end
 

--- a/path_10_9/src/creature.h
+++ b/path_10_9/src/creature.h
@@ -358,6 +358,10 @@ class Creature : virtual public Thing
 			return false;
 		}
 
+		virtual bool setCreatureMaster(Creature*) {
+			return false;
+		}
+
 		void onDeath();
 		virtual uint64_t getGainedExperience(Creature* attacker) const;
 		void addDamagePoints(Creature* attacker, int32_t damagePoints);

--- a/path_10_9/src/luascript.cpp
+++ b/path_10_9/src/luascript.cpp
@@ -2113,6 +2113,8 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Creature", "getMaster", LuaScriptInterface::luaCreatureGetMaster);
 	registerMethod("Creature", "setMaster", LuaScriptInterface::luaCreatureSetMaster);
 
+	registerMethod("Creature", "convince", LuaScriptInterface::luaCreatureConvince);
+
 	registerMethod("Creature", "getLight", LuaScriptInterface::luaCreatureGetLight);
 	registerMethod("Creature", "setLight", LuaScriptInterface::luaCreatureSetLight);
 
@@ -6886,6 +6888,32 @@ int LuaScriptInterface::luaCreatureGetMaster(lua_State* L)
 	return 1;
 }
 
+
+int LuaScriptInterface::luaCreatureConvince(lua_State* L)
+{
+	// creature:convince(master)
+	Creature* creature = getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	Creature* master = getCreature(L, 2);
+	if (master) {
+		pushBoolean(L, creature->convinceCreature(master));
+	} else {
+		master = creature->getMaster();
+		if (master) {
+			master->removeSummon(creature);
+			creature->incrementReferenceCounter();
+			creature->setDropLoot(true);
+		}
+		pushBoolean(L, true);
+	}
+	g_game.updateCreatureType(creature);
+	return 1;
+}
+
 int LuaScriptInterface::luaCreatureSetMaster(lua_State* L)
 {
 	// creature:setMaster(master)
@@ -6897,7 +6925,7 @@ int LuaScriptInterface::luaCreatureSetMaster(lua_State* L)
 
 	Creature* master = getCreature(L, 2);
 	if (master) {
-		pushBoolean(L, creature->convinceCreature(master));
+		pushBoolean(L, creature->setCreatureMaster(master));
 	} else {
 		master = creature->getMaster();
 		if (master) {

--- a/path_10_9/src/luascript.h
+++ b/path_10_9/src/luascript.h
@@ -761,6 +761,8 @@ class LuaScriptInterface
 		static int luaCreatureGetMaster(lua_State* L);
 		static int luaCreatureSetMaster(lua_State* L);
 
+		static int luaCreatureConvince(lua_State* L);
+
 		static int luaCreatureGetLight(lua_State* L);
 		static int luaCreatureSetLight(lua_State* L);
 

--- a/path_10_9/src/monster.h
+++ b/path_10_9/src/monster.h
@@ -143,6 +143,7 @@ class Monster final : public Creature
 		void onThink(uint32_t interval) final;
 
 		bool challengeCreature(Creature* creature) final;
+		bool setCreatureMaster(Creature *master);
 		bool convinceCreature(Creature* creature) final;
 
 		void setNormalCreatureLight() final;


### PR DESCRIPTION
Creating dedicated method to set a creature's master that isn't linked with the convince behavior. This fixes mattyx14/otxserver#199