### PR TITLE
removing wrong percent sign from armor description

### DIFF
--- a/path_10_9/src/item.cpp
+++ b/path_10_9/src/item.cpp
@@ -1232,7 +1232,7 @@ std::string Item::getDescription(const ItemType& it, int32_t lookDistance,
 					s << ", ";
 				}
 
-				s << getSkillName(i) << ' ' << std::showpos << it.abilities->skills[i] << std::noshowpos << '%';
+				s << getSkillName(i) << ' ' << std::showpos << it.abilities->skills[i] << std::noshowpos;
 			}
 
 			for (uint8_t i = SKILL_CRITICAL_HIT_CHANCE; i <= SKILL_LAST; i++) {


### PR DESCRIPTION
Armors with additional skill points was wrongly showing the percent sign in the additional skill, this resolves mattyx14/otxserver#145