### PR TITLE
rateMonsterHealth, rateMonsterAttack & rateMonsterDefense OTX3

### DIFF
--- a/path_8_6/src/configmanager.cpp
+++ b/path_8_6/src/configmanager.cpp
@@ -77,6 +77,18 @@ bool getGlobalBoolean(lua_State* L, const char* identifier, const bool defaultVa
 	return val != 0;
 }
 
+float getGlobalFloat(lua_State* L, const char* identifier, const float defaultValue = 0.0)
+{
+	lua_getglobal(L, identifier);
+	if (!lua_isnumber(L, -1)) {
+		return defaultValue;
+	}
+
+	float val = lua_tonumber(L, -1);
+	lua_pop(L, 1);
+	return val;
+}
+
 }
 
 bool ConfigManager::load()
@@ -169,6 +181,10 @@ bool ConfigManager::load()
 	integer[EXP_FROM_PLAYERS_LEVEL_RANGE] = getGlobalNumber(L, "expFromPlayersLevelRange", 75);
 	integer[MAX_PACKETS_PER_SECOND] = getGlobalNumber(L, "maxPacketsPerSecond", 25);
 
+	floating[RATE_MONSTER_HEALTH] = getGlobalFloat(L, "rateMonsterHealth", 1.0);
+	floating[RATE_MONSTER_ATTACK] = getGlobalFloat(L, "rateMonsterAttack", 1.0);
+	floating[RATE_MONSTER_DEFENSE] = getGlobalFloat(L, "rateMonsterDefense", 1.0);
+	
 	loaded = true;
 	lua_close(L);
 	return true;
@@ -210,4 +226,13 @@ bool ConfigManager::getBoolean(boolean_config_t what) const
 		return false;
 	}
 	return boolean[what];
+}
+
+float ConfigManager::getFloat(floating_config_t what) const
+{
+	if (what >= LAST_FLOATING_CONFIG) {
+		std::cout << "[Warning - ConfigManager::getFLoat] Accessing invalid index: " << what << std::endl;
+		return 0;
+	}
+	return floating[what];
 }

--- a/path_8_6/src/configmanager.h
+++ b/path_8_6/src/configmanager.h
@@ -64,7 +64,6 @@ class ConfigManager
 			DEFAULT_PRIORITY,
 			MAP_AUTHOR,
 			VERSION_STR,
-
 			LAST_STRING_CONFIG /* this must be the last one */
 		};
 
@@ -103,18 +102,28 @@ class ConfigManager
 			LAST_INTEGER_CONFIG /* this must be the last one */
 		};
 
+		enum floating_config_t {
+			RATE_MONSTER_HEALTH,
+			RATE_MONSTER_ATTACK,
+			RATE_MONSTER_DEFENSE,
+ 
+ 			LAST_FLOATING_CONFIG
+ 		};
+		
 		bool load();
 		bool reload();
 
 		const std::string& getString(string_config_t what) const;
 		int32_t getNumber(integer_config_t what) const;
 		bool getBoolean(boolean_config_t what) const;
+		float getFloat(floating_config_t what) const;
 
 	private:
 		std::string string[LAST_STRING_CONFIG] = {};
 		int32_t integer[LAST_INTEGER_CONFIG] = {};
 		bool boolean[LAST_BOOLEAN_CONFIG] = {};
-
+		float floating[LAST_FLOATING_CONFIG] = {};
+		
 		bool loaded = false;
 };
 


### PR DESCRIPTION
Hello, I opened an issue #219 asking for this, I've done a good part of it, including float values (it is mainly used with x.x values to make a better balancing of monsters)
I'm having problems with **rateMonsterAttack** and **rateMonsterDefense** since **rateMonsterHealth** is working ok. 

I don't know about sources or C, i'm "happy" with the result taking this into account. Of course I want it working. But I just searched about including float and then some copy/paste/edit on 0.4/0.3.7 that had this function.

They probably changed how the damages are calculed on monsters (defense/attack) and even if it compiled ok, the damages won't change, even if I add a really high value just to test.