### PR TITLE
Update unlocked prey slot if player has premium account

### DIFF
--- a/path_10_11/data/modules/scripts/prey system/preysystem.lua
+++ b/path_10_11/data/modules/scripts/prey system/preysystem.lua
@@ -245,25 +245,41 @@ function changeStateToActive(player, indexColumn)
 end
 
 function sendPreyData(player, indexColumn)
-	local isUnlockedColumn = player:isOpenColumn(indexColumn)
-	if (not isUnlockedColumn) then
-		-- STATE_LOCKED
-		changeStateToLocked(player, indexColumn)
-	elseif (player:isActive(indexColumn)) then
-		-- STATE_ACTIVE
-		changeStateToActive(player, indexColumn)
-	elseif (player:isBonusReroll(indexColumn)) then
-		-- STATE_SELECTION_CHANGE_MONSTER
-		changeStateToSelectionChangeMonster(player, indexColumn)
-	else
-		if (player:getBonusMonster(indexColumn) ~= "") then
-			player:removePreyMonster(player:getBonusMonster(indexColumn))
-			player:removeBonus(indexColumn)
+	if player:isPremium() then
+		if (player:isActive(indexColumn)) then
+			-- STATE_ACTIVE
+			changeStateToActive(player, indexColumn)
+		elseif (player:isBonusReroll(indexColumn)) then
+			-- STATE_SELECTION_CHANGE_MONSTER
+			changeStateToSelectionChangeMonster(player, indexColumn)
+		else
+			if (player:getBonusMonster(indexColumn) ~= "") then
+				player:removePreyMonster(player:getBonusMonster(indexColumn))
+				player:removeBonus(indexColumn)
+			end
+			-- STATE_SELECTION
+			changeStateToSelection(player, indexColumn)
 		end
-		-- STATE_SELECTION
-		changeStateToSelection(player, indexColumn)
+	else
+		local isUnlockedColumn = player:isOpenColumn(indexColumn)
+		if (not isUnlockedColumn) then
+			-- STATE_LOCKED
+			changeStateToLocked(player, indexColumn)
+		elseif (player:isActive(indexColumn)) then
+			-- STATE_ACTIVE
+			changeStateToActive(player, indexColumn)
+		elseif (player:isBonusReroll(indexColumn)) then
+			-- STATE_SELECTION_CHANGE_MONSTER
+			changeStateToSelectionChangeMonster(player, indexColumn)
+		else
+			if (player:getBonusMonster(indexColumn) ~= "") then
+				player:removePreyMonster(player:getBonusMonster(indexColumn))
+				player:removeBonus(indexColumn)
+			end
+			-- STATE_SELECTION
+			changeStateToSelection(player, indexColumn)
+		end
 	end
-	-- STATE_SELECTION_CHANGE_MONSTER IS FROM BONUSREROLL
 end
 
 local function getMonsterName(player, column, index)

--- a/path_10_11/data/modules/scripts/prey system/preysystem.lua
+++ b/path_10_11/data/modules/scripts/prey system/preysystem.lua
@@ -245,41 +245,25 @@ function changeStateToActive(player, indexColumn)
 end
 
 function sendPreyData(player, indexColumn)
-	if player:isPremium() then
-		if (player:isActive(indexColumn)) then
-			-- STATE_ACTIVE
-			changeStateToActive(player, indexColumn)
-		elseif (player:isBonusReroll(indexColumn)) then
-			-- STATE_SELECTION_CHANGE_MONSTER
-			changeStateToSelectionChangeMonster(player, indexColumn)
-		else
-			if (player:getBonusMonster(indexColumn) ~= "") then
-				player:removePreyMonster(player:getBonusMonster(indexColumn))
-				player:removeBonus(indexColumn)
-			end
-			-- STATE_SELECTION
-			changeStateToSelection(player, indexColumn)
-		end
+	local isUnlockedColumn = player:isOpenColumn(indexColumn)
+	if (not isUnlockedColumn) and (not player:isPremium()) then
+		-- STATE_LOCKED
+		changeStateToLocked(player, indexColumn)
+	elseif (player:isActive(indexColumn)) then
+		-- STATE_ACTIVE
+		changeStateToActive(player, indexColumn)
+	elseif (player:isBonusReroll(indexColumn)) then
+		-- STATE_SELECTION_CHANGE_MONSTER
+		changeStateToSelectionChangeMonster(player, indexColumn)
 	else
-		local isUnlockedColumn = player:isOpenColumn(indexColumn)
-		if (not isUnlockedColumn) then
-			-- STATE_LOCKED
-			changeStateToLocked(player, indexColumn)
-		elseif (player:isActive(indexColumn)) then
-			-- STATE_ACTIVE
-			changeStateToActive(player, indexColumn)
-		elseif (player:isBonusReroll(indexColumn)) then
-			-- STATE_SELECTION_CHANGE_MONSTER
-			changeStateToSelectionChangeMonster(player, indexColumn)
-		else
-			if (player:getBonusMonster(indexColumn) ~= "") then
-				player:removePreyMonster(player:getBonusMonster(indexColumn))
-				player:removeBonus(indexColumn)
-			end
-			-- STATE_SELECTION
-			changeStateToSelection(player, indexColumn)
+		if (player:getBonusMonster(indexColumn) ~= "") then
+			player:removePreyMonster(player:getBonusMonster(indexColumn))
+			player:removeBonus(indexColumn)
 		end
+		-- STATE_SELECTION
+		changeStateToSelection(player, indexColumn)
 	end
+	-- STATE_SELECTION_CHANGE_MONSTER IS FROM BONUSREROLL
 end
 
 local function getMonsterName(player, column, index)

--- a/path_10_11/data/modules/scripts/prey system/preysystem.lua
+++ b/path_10_11/data/modules/scripts/prey system/preysystem.lua
@@ -299,7 +299,7 @@ function CheckPrey(player, msg)
 	elseif (PreyAction == 2) then
 		local PreyIndex = msg:getByte() -- monster index
 		--print(PreyColumn.. " e " ..PreyAction.. " e " ..PreyIndex)
-		if (getUnlockedColumn(player) < PreyColumn) then
+		if (getUnlockedColumn(player) < PreyColumn) and (not player:isPremium()) then
 			return sendError(player, "[ERROR] You don't have this column unlocked.")
 		end
 


### PR DESCRIPTION
According to client 11.47, if the player is premium, it has the right of the prey slot to be unlocked. Adding this simple condition, the slot will be released if it is premium. And if it is not, the slot will remain locked.