### PR TITLE
Party self-invite crash bug fix

### DIFF
--- a/path_10_x/sources/game.cpp
+++ b/path_10_x/sources/game.cpp
@@ -5335,6 +5335,9 @@ bool Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 	if(!player || player->isRemoved())
 		return false;
 
+	if(playerId == invitedId)
+		return false;
+
 	Player* invitedPlayer = getPlayerByID(invitedId);
 	if(!invitedPlayer || invitedPlayer->isRemoved() || invitedPlayer->isInviting(player))
 		return false;

--- a/path_7_x/sources/game.cpp
+++ b/path_7_x/sources/game.cpp
@@ -5101,6 +5101,9 @@ bool Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 	if(!player || player->isRemoved())
 		return false;
 
+	if(playerId == invitedId)
+		return false;
+
 	if(player->hasCondition(CONDITION_EXHAUST, 5))
 	{
 		player->sendTextMessage(MSG_STATUS_SMALL, "You have to wait a while.");

--- a/path_8_1x/sources/game.cpp
+++ b/path_8_1x/sources/game.cpp
@@ -5137,6 +5137,9 @@ bool Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 	if(!player || player->isRemoved())
 		return false;
 
+	if(playerId == invitedId)
+		return false;
+
 	if(player->hasCondition(CONDITION_EXHAUST, 5))
 	{
 		player->sendTextMessage(MSG_STATUS_SMALL, "You have to wait a while.");

--- a/path_8_5x/sources/game.cpp
+++ b/path_8_5x/sources/game.cpp
@@ -5489,6 +5489,9 @@ bool Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 	if(!player || player->isRemoved())
 		return false;
 
+	if(playerId == invitedId)
+		return false;
+
 	if(player->hasCondition(CONDITION_EXHAUST, 5))
 	{
 		player->sendTextMessage(MSG_STATUS_SMALL, "You have to wait a while.");

--- a/path_8_6x/sources/game.cpp
+++ b/path_8_6x/sources/game.cpp
@@ -5491,6 +5491,9 @@ bool Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 	if(!player || player->isRemoved())
 		return false;
 
+	if(playerId == invitedId)
+		return false;
+
 	if(player->hasCondition(CONDITION_EXHAUST, 5))
 	{
 		player->sendTextMessage(MSG_STATUS_SMALL, "You have to wait a while.");

--- a/path_8_7x/sources/game.cpp
+++ b/path_8_7x/sources/game.cpp
@@ -5352,6 +5352,9 @@ bool Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 	if(!player || player->isRemoved())
 		return false;
 
+	if(playerId == invitedId)
+		return false;
+
 	if(player->hasCondition(CONDITION_EXHAUST, 5))
 	{
 		player->sendTextMessage(MSG_STATUS_SMALL, "You have to wait a while.");


### PR DESCRIPTION
Fix easy to generate crash bug. You can invite yourself to Party when you are not in any party:
https://otland.net/threads/crash-party-tfs-0-4-8-60.258129/#post-2498323