### PR TITLE
Party self-invite crash bug fix

### DIFF
--- a/path_10_11/src/game.cpp
+++ b/path_10_11/src/game.cpp
@@ -4909,6 +4909,9 @@ void Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 		return;
 	}
 
+	if (playerId == invitedId)
+		return;
+
 	Player* invitedPlayer = getPlayerByID(invitedId);
 	if (!invitedPlayer || invitedPlayer->isInviting(player)) {
 		return;

--- a/path_7_7/src/game.cpp
+++ b/path_7_7/src/game.cpp
@@ -4053,6 +4053,9 @@ void Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 		return;
 	}
 
+	if (playerId == invitedId)
+		return;
+
 	Player* invitedPlayer = getPlayerByID(invitedId);
 	if (!invitedPlayer || invitedPlayer->isInviting(player)) {
 		return;

--- a/path_8_5/src/game.cpp
+++ b/path_8_5/src/game.cpp
@@ -4439,6 +4439,9 @@ void Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 		return;
 	}
 
+	if (playerId == invitedId)
+		return;
+
 	Player* invitedPlayer = getPlayerByID(invitedId);
 	if (!invitedPlayer || invitedPlayer->isInviting(player)) {
 		return;

--- a/path_8_6/src/game.cpp
+++ b/path_8_6/src/game.cpp
@@ -4439,6 +4439,9 @@ void Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 		return;
 	}
 
+	if (playerId == invitedId)
+		return;
+
 	Player* invitedPlayer = getPlayerByID(invitedId);
 	if (!invitedPlayer || invitedPlayer->isInviting(player)) {
 		return;


### PR DESCRIPTION
Same fix as in previous Pull Request, but for otxserv3.

Fix easy to generate crash bug. You can invite yourself to Party when you are not in any party:
https://otland.net/threads/crash-party-tfs-0-4-8-60.258129/#post-2498323