### PR TITLE
Fixes monster beam casting through walls

### DIFF
--- a/path_8_6x/sources/combat.cpp
+++ b/path_8_6x/sources/combat.cpp
@@ -1196,6 +1196,14 @@ CombatArea::CombatArea(const CombatArea& rhs)
 bool CombatArea::getList(const Position& centerPos, const Position& targetPos, std::list<Tile*>& list) const
 {
 	Tile* tile = g_game.getTile(targetPos);
+	
+	if (tile->hasProperty(BLOCKPROJECTILE))
+		return false;
+	if (tile->hasFlag(TILESTATE_FLOORCHANGE))
+		return false;
+	if (tile->getTeleportItem())
+		return false;
+	
 	const MatrixArea* area = getArea(centerPos, targetPos);
 	if(!area)
 		return false;


### PR DESCRIPTION
Fixes monsters being able to cast beam spells through walls when targeting a player, example below:

https://gyazo.com/8d779c211c003b7ae2c83b132d598f43