### PR TITLE
Fixes SQL Overload

### DIFF
--- a/path_8_6x/sources/protocolgame.cpp
+++ b/path_8_6x/sources/protocolgame.cpp
@@ -527,7 +527,12 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 
 	bool gamemaster = (msg.get<char>() != (char)0);
 	std::string name = msg.getString(), character = msg.getString(), password = msg.getString();
-
+	if (name.empty() || !IOLoginData::getInstance()->playerExists(character))
+	{
+		disconnectClient(0x0A, "This character does not exist.");
+		return;
+	}
+	
 	msg.skip(6);
 	if(!g_config.getBool(ConfigManager::MANUAL_ADVANCED_CONFIG))
 	{


### PR DESCRIPTION
Apparently there's some people using a packet editor program to manipulate the login packets and cause the server to be inaccessible.This is achieved by login in with an normal account and then trying to enter the game with a character that does not exist multiple times, causing the mysql Database to overload.

Note: This must be extended to the other versions(8.7x, 8.5x...) I currently can't test it on the other, that's why I haven't extended the fix, but it's safe to assume that the problem persist on the others too.