### PR TITLE
Scripted Weapons now display critical hits

### DIFF
--- a/path_8_6x/sources/combat.cpp
+++ b/path_8_6x/sources/combat.cpp
@@ -89,6 +89,7 @@ bool Combat::getMinMaxValues(Creature* creature, Creature* target, CombatParams&
 
 				case FORMULA_SKILL:
 				{
+					bool crit = false;
 					Item* item = player->getWeapon(false);
 					if(const Weapon* weapon = g_weapons->getWeapon(item))
 					{
@@ -99,14 +100,18 @@ bool Combat::getMinMaxValues(Creature* creature, Creature* target, CombatParams&
 							_params.element.damage = random_range((int32_t)0, (int32_t)(_params.element.damage * maxa + maxb), DISTRO_NORMAL);
 						}
 
-						max = (int32_t)(weapon->getWeaponDamage(player, target, item, true) * maxa + maxb);
+						max = (int32_t)(weapon->getWeaponDamage(player, target, item, crit, true) * maxa + maxb);
 						if(params.useCharges && item->hasCharges() && g_config.getBool(ConfigManager::REMOVE_WEAPON_CHARGES))
 							g_game.transformItem(item, item->getID(), std::max((int32_t)0, ((int32_t)item->getCharges()) - 1));
 					}
 					else
 						max = (int32_t)maxb;
 
-					min = (int32_t)minb;
+					if (crit)
+						min = max;
+					else
+						min = (int32_t)minb;
+
 					if(maxc && std::abs(max) < std::abs(maxc))
 						max = maxc;
 

--- a/path_8_6x/sources/weapons.cpp
+++ b/path_8_6x/sources/weapons.cpp
@@ -399,8 +399,8 @@ bool Weapon::internalUseWeapon(Player* player, Item* item, Creature* target, int
 		CombatParams _params = params;
 		_params.element.type = item->getElementType();
 		_params.element.damage = getWeaponElementDamage(player, item);
-
-		int32_t damage = (getWeaponDamage(player, target, item) * modifier) / 100;
+		bool isCritical = false;
+		int32_t damage = (getWeaponDamage(player, target, item, isCritical) * modifier) / 100;
 		Combat::doCombatHealth(player, target, damage, damage, _params);
 	}
 
@@ -613,7 +613,7 @@ bool WeaponMelee::getSkillType(const Player* player, const Item* item,
 	return false;
 }
 
-int32_t WeaponMelee::getWeaponDamage(const Player* player, const Creature*, const Item* item, bool maxDamage /*= false*/) const
+int32_t WeaponMelee::getWeaponDamage(const Player* player, const Creature*, const Item* item, bool& isCritical, bool maxDamage /*= false*/) const
 {
 	int32_t attackSkill = player->getWeaponSkill(item), attackValue = std::max((int32_t)0,
 		(int32_t(item->getAttack() + item->getExtraAttack()) - item->getElementDamage()));
@@ -622,6 +622,7 @@ int32_t WeaponMelee::getWeaponDamage(const Player* player, const Creature*, cons
 	double maxValue = Weapons::getMaxWeaponDamage(player->getLevel(), attackSkill, attackValue, attackFactor);
 	if(player->getCriticalHitChance() + g_config.getNumber(ConfigManager::CRITICAL_HIT_CHANCE) >= random_range(1, 100))
 	{
+		isCritical = true;
 		maxDamage = true;
 		maxValue *= g_config.getDouble(ConfigManager::CRITICAL_HIT_MUL);
 		player->sendCritical();
@@ -872,7 +873,7 @@ void WeaponDistance::onUsedAmmo(Player* player, Item* item, Tile* destTile) cons
 		Weapon::onUsedAmmo(player, item, destTile);
 }
 
-int32_t WeaponDistance::getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage /*= false*/) const
+int32_t WeaponDistance::getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool& isCritical, bool maxDamage /*= false*/) const
 {
 	int32_t attackValue = attack;
 	if(item->getWeaponType() == WEAPON_AMMO)
@@ -887,6 +888,7 @@ int32_t WeaponDistance::getWeaponDamage(const Player* player, const Creature* ta
 	double maxValue = Weapons::getMaxWeaponDamage(player->getLevel(), attackSkill, attackValue, attackFactor);
 	if(player->getCriticalHitChance() + g_config.getNumber(ConfigManager::CRITICAL_HIT_CHANCE) >= random_range(1, 100))
 	{
+		isCritical = true;
 		maxDamage = true;
 		maxValue *= g_config.getDouble(ConfigManager::CRITICAL_HIT_MUL);
 		player->sendCritical();
@@ -968,7 +970,7 @@ bool WeaponWand::configureWeapon(const ItemType& it)
 	return Weapon::configureWeapon(it);
 }
 
-int32_t WeaponWand::getWeaponDamage(const Player* player, const Creature*, const Item*, bool maxDamage /* = false*/) const
+int32_t WeaponWand::getWeaponDamage(const Player* player, const Creature*, const Item*, bool& isCritical, bool maxDamage /* = false*/) const
 {
 	float multiplier = 1.0f;
 	if(Vocation* vocation = player->getVocation())

--- a/path_8_6x/sources/weapons.h
+++ b/path_8_6x/sources/weapons.h
@@ -78,7 +78,7 @@ class Weapon : public Event
 		CombatParams getCombatParam() const {return params;}
 
 		virtual bool useWeapon(Player* player, Item* item, Creature* target) const;
-		virtual int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const = 0;
+		virtual int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool& isCritical, bool maxDamage = false) const = 0;
 		virtual int32_t getWeaponElementDamage(const Player*, const Item*, bool = false) const {return 0;}
 
 		uint32_t getReqLevel() const {return level;}
@@ -121,7 +121,7 @@ class WeaponMelee : public Weapon
 		virtual ~WeaponMelee() {}
 
 		virtual bool useWeapon(Player* player, Item* item, Creature* target) const;
-		virtual int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const;
+		virtual int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool& isCritical, bool maxDamage = false) const;
 		virtual int32_t getWeaponElementDamage(const Player* player, const Item* item, bool maxDamage = false) const;
 
 	protected:
@@ -139,7 +139,7 @@ class WeaponDistance : public Weapon
 		virtual int32_t playerWeaponCheck(Player* player, Creature* target) const;
 
 		virtual bool useWeapon(Player* player, Item* item, Creature* target) const;
-		virtual int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const;
+		virtual int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool& isCritical, bool maxDamage = false) const;
 
 	protected:
 		virtual void onUsedAmmo(Player* player, Item* item, Tile* destTile) const;
@@ -157,7 +157,7 @@ class WeaponWand : public Weapon
 		virtual bool configureEvent(xmlNodePtr p);
 		virtual bool configureWeapon(const ItemType& it);
 
-		virtual int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const;
+		virtual int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool& isCritical, bool maxDamage = false) const;
 
 	protected:
 		virtual bool getSkillType(const Player*, const Item*, skills_t&, uint64_t&) const {return false;}


### PR DESCRIPTION
Scripted weapons with COMBAT_FORMULA_SKILL(example: viper star) now properly display critical hits