### PR TITLE
Fix query error using Visual Studio 2019

### DIFF
--- a/path_8_6/src/iologindata.cpp
+++ b/path_8_6/src/iologindata.cpp
@@ -664,7 +664,7 @@ bool IOLoginData::savePlayer(Player* player)
 	query << "`posz` = " << loginPosition.getZ() << ',';
 
 	query << "`cap` = " << (player->capacity / 100) << ',';
-	query << "`sex` = " << player->sex << ',';
+	query << "`sex` = " << static_cast<uint16_t>(player->sex) << ',';
 
 	if (player->lastLoginSaved != 0) {
 		query << "`lastlogin` = " << player->lastLoginSaved << ',';


### PR DESCRIPTION
When insert to the database a value uint8_t it presents a special symbol, generating error in the console and consequently error when saving the player, this is a rather serious problem.