### PR TITLE
fix: travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ addons:
       - libboost-dev
       - libboost-system-dev
       - libboost-iostreams-dev
+      - libboost-filesystem-dev
       - liblua5.2-dev
       - libluajit-5.1-dev
       - libmysqlclient-dev


### PR DESCRIPTION
add missing dependency libboost-filesystem