### PR TITLE
Verification to leave party in protection zone

### DIFF
--- a/path_8_6/src/game.cpp
+++ b/path_8_6/src/game.cpp
@@ -4636,8 +4636,10 @@ void Game::playerLeaveParty(uint32_t playerId)
 	}
 
 	Party* party = player->getParty();
-	if (!party || player->hasCondition(CONDITION_INFIGHT)) {
-		return;
+	if(player->getZone() != ZONE_PROTECTION) {
+		if (!party || player->hasCondition(CONDITION_INFIGHT)) {
+			return;
+		}
 	}
 
 	party->leaveParty(player);


### PR DESCRIPTION
By getting the CONDITION_INFIGHT condition even players in the protection zone could not leave the party