### PR TITLE
FIX TFS - Fix lost percent calculation on death

### DIFF
--- a/path_8_6/src/player.cpp
+++ b/path_8_6/src/player.cpp
@@ -3819,11 +3819,13 @@ double Player::getLostPercent() const
 		lossPercent = 10;
 	}
 
+	double percentReduction = 0;
 	if (isPromoted()) {
-		lossPercent *= 0.7;
+		percentReduction += 30;
 	}
 
-	return lossPercent * pow(0.92, blessingCount) / 100;
+	percentReduction += blessingCount * 8;
+	return lossPercent * (1 - (percentReduction / 100.)) / 100.;
 }
 
 void Player::learnInstantSpell(const std::string& spellName)


### PR DESCRIPTION
The current TFS uses some kind of custom formula for calculating loss percent on death. This pull request implements the formula as it is described on wiki. (by gunzino)