### PR TITLE
Fix wrong boolean to check classicAttackSpeed

### DIFF
--- a/sources/player.cpp
+++ b/sources/player.cpp
@@ -3826,7 +3826,7 @@ void Player::doAttacking(uint32_t)
 
 	if(const Weapon* _weapon = g_weapons->getWeapon(weapon))
 	{
-		if(!g_config.getBool(ConfigManager::CLASSIC_EQUIPMENT_SLOTS) && _weapon->interruptSwing() && !canDoAction())
+		if(!g_config.getBool(ConfigManager::CLASSIC_ATTACK_SPEED) && _weapon->interruptSwing() && !canDoAction())
 		{
 			SchedulerTask* task = createSchedulerTask(getNextActionTime(),
 				boost::bind(&Game::checkCreatureAttack, &g_game, getID()));


### PR DESCRIPTION
- I only realized it after previous pull request been merged
- Sorry, probably my text editor's autocomplete made this mistake