### PR TITLE
otxserv2: Fix aggressive area spells not working with black skull system off

### DIFF
--- a/sources/spells.cpp
+++ b/sources/spells.cpp
@@ -897,8 +897,7 @@ bool Spell::checkInstantSpell(Player* player, Creature* creature)
 		}
 		else
 		{
-			if(!isAggressive)
-				return true;
+			return true;
 		}
 
 		player->sendCancelMessage(RET_YOUMAYNOTCASTAREAONBLACKSKULL);
@@ -1116,8 +1115,7 @@ bool Spell::checkRuneSpell(Player* player, const Position& toPos)
 		}
 		else
 		{
-			if(!isAggressive)
-				return true;
+			return true;
 		}
 
 		player->sendCancelMessage(RET_YOUMAYNOTCASTAREAONBLACKSKULL);


### PR DESCRIPTION
# Description

Not sure if I'm missing something here, but it seems that if you turn off the black skull system in the config, aggressive area spells just don't work at all. (branch `otxserv2`)

The patch in this PR appears to fix the issue (look at the surrounding code (`if (!needTarget)` block) and it's pretty obvious why it happens)

## Type of change

  - Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- Checked if aggressive area spells work on a local server both before and after this patch. After this patch, they work.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [N/A] I checked the PR checks reports
  - [N/A] I have commented my code, particularly in hard-to-understand areas
  - [N/A] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [N/A] I have added tests that prove my fix is effective or that my feature works
