### PR TITLE
change fleeing behavior

### DIFF
--- a/sources/monster.cpp
+++ b/sources/monster.cpp
@@ -1433,7 +1433,7 @@ bool Monster::isWalkable() const
 bool Monster::isFleeing() const
 {
 	std::string value;
-	if(!getStorage("fleeing", value))
+	if(!getStorage("fleeing", value) && targetChangeCooldown <= 0)
 		return getHealth() <= mType->runAwayHealth;
 
 	return booleanString(value);


### PR DESCRIPTION
# Description

If knight challenge the target, he can not run when the health is low. Is that make sense for everybody else? I do not know if that is relevant. But I think that is the actual behavior in Real Tibia today.

## Behaviour
### **Actual**

The "Challenge" spell not avoid target from running away with low health.

### **Expected**

After cast "Challenge" the target will not run away with low health.

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [ ] Cast the spell "Challenge" (exeta res) with knight vocation, and the target should expect to run with low health.

**Test Configuration**:

  - Server Version:  Windows 10 (localhost)
  - Client: 8.6
  - Operating System: Windows 10