### PR TITLE
 Fixes bug with stairs not going up or down

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -15061,10 +15061,10 @@
 	<item id="7919" article="an" name="armillary sphere"/>
 	<item id="7920-7923" article="a" name="chalk board"/>
 	<item id="7924" name="stone stairs">
-		<attribute key="floorchange" value="southalt"/>
+		<attribute key="floorchange" value="southex"/>
 	</item>
 	<item id="7925" name="stone stairs">
-		<attribute key="floorchange" value="eastalt"/>
+		<attribute key="floorchange" value="eastex"/>
 	</item>
 	<item id="7926" article="a" name="dead troll">
 		<attribute key="containerSize" value="7"/>
@@ -15920,7 +15920,7 @@
 		<attribute key="floorchange" value="west"/>
 	</item>
 	<item id="8716" name="stone stairs">
-		<attribute key="floorchange" value="southalt"/>
+		<attribute key="floorchange" value="southex"/>
 	</item>
 	<item id="8717" name="lock pick">
 		<attribute key="weight" value="85"/>


### PR DESCRIPTION
# Description

Corrects the action of going up and down stairs that were with floorchange eastalt, southalt

## Behaviour
### **Actual**

player tries to climb the stairs and nothing happens, when trying to go down he gets stuck in front of the stairs completely bugged.

### **Expected**

go up and down the stairs correctly

### Fixes #769

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Going up and down stairs with id 7924
  - [x] Going up and down stairs with id 7925
  - [x] Going up and down stairs with id 8716

**Test Configuration**:

  - Server Version: 8.60
  - Client: otcv8
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  
  
 
