### PR TITLE
fix: count arm only if it equiped on the right slot

### DIFF
--- a/sources/player.cpp
+++ b/sources/player.cpp
@@ -454,7 +454,12 @@ int32_t Player::getArmor() const
 	for(; i < SLOT_LAST; ++i)
 	{
 		if(Item* item = getInventoryItem((slots_t)i))
-			armor += item->getArmor();
+		{
+			if (item->getWieldPosition() == i)
+			{
+				armor += item->getArmor();
+			}
+		}
 	}
 
 	if(vocation->getMultiplier(MULTIPLIER_ARMOR) != 1.0)


### PR DESCRIPTION
Fixes #772